### PR TITLE
First Arduino Code that clears error using Cardboard box test kit for Herkulex

### DIFF
--- a/test/io/outputs/actuators/herkulex/clearError/clearErrorTestCode/clearErrorTestCode.ino
+++ b/test/io/outputs/actuators/herkulex/clearError/clearErrorTestCode/clearErrorTestCode.ino
@@ -1,0 +1,37 @@
+#include <Herkulex.h>
+int n=6; //motor ID - verify your ID !!!!
+
+void setup()  
+{
+  delay(2000);  //a delay to have time for serial monitor opening
+  Serial.begin(57600);   // Open serial communications
+  Serial.println("Begin");
+  // Herkulex.beginSerial1(57600); //open serial port 1
+  Herkulex.begin(57600,18,19);
+  Herkulex.reboot(n); //reboot first motor
+  delay(500); 
+  Herkulex.initialize(); //initialize motors
+  delay(200);  
+  Herkulex.clearError(n);
+  Serial.println("Clearing Motor Errors on Reboot...");
+  
+}
+
+void loop(){
+
+  Serial.println("Move Angle: -100 degrees");
+  Herkulex.moveOneAngle(n, -100, 1000, LED_BLUE); //move motor with 300 speed  
+  delay(1200);
+  // Serial.print("Get servo Angle:");
+  // Serial.println(Herkulex.getAngle(n));
+  Serial.println("Move Angle: 100 degrees");
+  Herkulex.moveOneAngle(n, 100, 1000, LED_GREEN); //move motor with 300 speed  
+  delay(1200);
+  //Herkulex.clearError(n);
+  Serial.println(Herkulex.stat(n));
+  // Serial.print("Get servo Angle:");
+  // Serial.println(Herkulex.getAngle(n));
+  
+}
+
+


### PR DESCRIPTION
This code allows single herkulex motor to be moved to a specified angle and tested from the cardboard test kit using Arduino mega. This code will clear pending errors from the motor to get it to run again, this will only clear the error once in setup() so any compounding errors will not be cleared. 